### PR TITLE
Asign project id in dataset from interval value of the workflow

### DIFF
--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -20,6 +20,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 import { BackendService } from '../core/services/backend.service';
+import { LocalStorageService } from '../core/services/local-storage.service';
 import { UserCommunicationService } from '../core/services/user-communication.service';
 
 import { Dataset } from '../shared/dataset';
@@ -51,11 +52,13 @@ export class DataSetCreationComponent implements OnInit {
   constructor(
     private formBuilder: FormBuilder,
     private backendService: BackendService,
+    private localStorage: LocalStorageService,
     private userCommunication: UserCommunicationService
     ) {}
 
   ngOnInit(): void {
     this.newDataSet = new Dataset();
+    this.newDataSet.project_id = this.localStorage.projectId;
     this.elegibilityCriteriaList = [];
     this.newDataSet.eligibility_criteria = this.elegibilityCriteriaList;
     this.newElegibilityCriteria = new ElegibilityCriteria();


### PR DESCRIPTION
## Proposed Changes

  - Calling services should include project-id value

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #50

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

  - Calling services include objects that have project-id as a field
  - An horizontal service holds the project-id and is filled when the project is created

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
