### PR TITLE
Add functionality to see the details of a feature set.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -41,6 +41,7 @@ const routes: Routes = [
   { path: 'ucmenu', component: UseCaseMenuComponent},
   { path: 'fscreation', component: FeatureSetCreationComponent},
   { path: 'fslist', component: FeatureSetListComponent},
+  { path: 'fsdetails', component: FeatureSetCreationComponent},
   { path: 'dscreation', component: DataSetCreationComponent},
   { path: 'dsdashboard', component: DataSetDashboardComponent},
   { path: 'mdashboard', component: ModelDashboardComponent},

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -89,7 +89,6 @@ import { CoverPageComponent } from './cover-page/cover-page.component';
 import { LogoutDialogComponent } from './header/logout-dialog/logout-dialog.component';
 import { NewVariableDialogComponent } from './feature-set-creation/new-variable-dialog/new-variable-dialog.component';
 
-
 @NgModule({
   declarations: [
     AppComponent,

--- a/src/app/feature-set-creation/feature-set-creation.component.html
+++ b/src/app/feature-set-creation/feature-set-creation.component.html
@@ -1,19 +1,19 @@
 <div class="nav-path">
-  <a mat-button [routerLink]="['/uclist']">Home</a>>><a mat-button [routerLink]="['/ucmenu']">Use case</a>>><a mat-button [routerLink]="['/fslist']">Feature set management</a>>><a mat-button color="primary">Feature set creation</a>
+  <a mat-button [routerLink]="['/uclist']">Home</a>>><a mat-button [routerLink]="['/ucmenu']">Use case</a>>><a mat-button [routerLink]="['/fslist']">Feature set management</a>>><a mat-button color="primary">{{componentDirection}}</a>
 </div>
 
 <mat-divider></mat-divider>
 <div class="content">
-  <h3>Create a new feature set</h3>
+  <h3>{{componentTitle}}</h3>
 
   <mat-form-field appearance="fill">
-    <mat-label ngDefaultControl [(ngModel)]='name'>Feature set name</mat-label>
-    <input matInput>
+    <mat-label>Feature set name</mat-label>
+    <input matInput ngDefaultControl [(ngModel)]='name'>
   </mat-form-field>
   <br>
   <mat-form-field appearance="fill">
-    <mat-label ngDefaultControl [(ngModel)]='description'>Description</mat-label>
-    <input matInput>
+    <mat-label>Description</mat-label>
+    <input matInput ngDefaultControl [(ngModel)]='description'>
   </mat-form-field>
 
   <br>

--- a/src/app/feature-set-creation/feature-set-creation.component.ts
+++ b/src/app/feature-set-creation/feature-set-creation.component.ts
@@ -40,6 +40,8 @@ export class FeatureSetCreationComponent implements OnInit {
   name: string;
   description: string;
   newVariable: Variable;
+  componentTitle: string;
+  componentDirection: string;
 
   @ViewChild(MatTable) table: MatTable<any>;
   displayedColumns: string[] = ['name', 'description', 'variable_type', 'variable_data_type', 'fhir_query', 'fhir_path', 'delete'];
@@ -54,6 +56,22 @@ export class FeatureSetCreationComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+
+    if (history.state.selectedFeatureSet) {
+      this.fillFields();
+      this.componentTitle = 'Edit feature set';
+      this.componentDirection = 'Feature set edition';
+    } else {
+      this.componentTitle = 'Create a new feature set';
+      this.componentDirection = 'Feature set creation';
+    }
+
+  }
+
+  fillFields(): void {
+    this.name = history.state.selectedFeatureSet.name;
+    this.description = history.state.selectedFeatureSet.description ;
+    this.dataSource = history.state.selectedFeatureSet.variables;
   }
 
   onNewVariable(): void {
@@ -79,15 +97,20 @@ export class FeatureSetCreationComponent implements OnInit {
     newFeatureSet.description = this.description;
     newFeatureSet.project_id = this.localStorage.projectId;
     newFeatureSet.variables = this.dataSource;
-    console.log('Feature set to save: ' + JSON.stringify(newFeatureSet));
-    this.backendService.postFeatureset(newFeatureSet).subscribe(
-      (data) => {
-        console.log('New feature set creation answer received! ' + JSON.stringify(data));
-      },
-      (err) => {
-        this.backendService.handleError('home', err);
-        this.userCommunication.createMessage(this.userCommunication.ERROR, 'New feature set creation failed!');
-      });
+    console.log('Feature set to save: ', newFeatureSet);
+    if (history.state.selectedFeatureSet) {
+      console.log('Update existent feature set.');
+    } else {
+
+      this.backendService.postFeatureset(newFeatureSet).subscribe(
+        (data) => {
+          console.log('New feature set creation answer received! ' + JSON.stringify(data));
+        },
+        (err) => {
+          this.backendService.handleError('home', err);
+          this.userCommunication.createMessage(this.userCommunication.ERROR, 'New feature set creation failed!');
+        });
+      }
   }
 
   onCancel(): void {

--- a/src/app/feature-set-list/feature-set-list.component.ts
+++ b/src/app/feature-set-list/feature-set-list.component.ts
@@ -32,7 +32,6 @@ export class FeatureSetListComponent implements OnInit {
 
   displayedColumns: string[] = ['name', 'description', 'variables', 'created_by', 'created_on', 'details'];
   dataSource = [];
-  test = 'hola mundo.';
 
   constructor(
     private backendService: BackendService,

--- a/src/app/feature-set-list/feature-set-list.component.ts
+++ b/src/app/feature-set-list/feature-set-list.component.ts
@@ -16,10 +16,12 @@
  * information in the project root.
  */
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, EventEmitter, Output } from '@angular/core';
 
 import { BackendService } from '../core/services/backend.service';
 import { UserCommunicationService } from '../core/services/user-communication.service';
+import { Router } from '@angular/router';
+
 
 @Component({
   selector: 'app-feature-set-list',
@@ -27,12 +29,15 @@ import { UserCommunicationService } from '../core/services/user-communication.se
   styleUrls: ['./feature-set-list.component.css']
 })
 export class FeatureSetListComponent implements OnInit {
+
   displayedColumns: string[] = ['name', 'description', 'variables', 'created_by', 'created_on', 'details'];
   dataSource = [];
+  test = 'hola mundo.';
 
   constructor(
     private backendService: BackendService,
-    private userCommunication: UserCommunicationService
+    private userCommunication: UserCommunicationService,
+    private router: Router,
     ) { }
 
     ngOnInit(): void {
@@ -42,8 +47,8 @@ export class FeatureSetListComponent implements OnInit {
     getFeatureSetList(): void {
       this.backendService.getFeaturesetsList().subscribe(
         (featuresetslist) => {
-          console.log(featuresetslist);
           this.dataSource = featuresetslist;
+          console.log('datasource de las listas', this.dataSource)
         },
         (err) => {
           this.backendService.handleError('home', err);
@@ -52,9 +57,10 @@ export class FeatureSetListComponent implements OnInit {
     }
 
     onSelectFeatureSet(selectedFeatureSet): void {
-      console.log('The selected feature set is: ' + selectedFeatureSet);
+      console.log('The selected feature set is: ', selectedFeatureSet);
       // TO DO Feature set details dialog
-      this.userCommunication.createMessage(this.userCommunication.INFO, 'Not ready yet');
+     // this.userCommunication.createMessage(this.userCommunication.INFO, 'Not ready yet');
+      this.router.navigate(['/fsdetails'], {state: {selectedFeatureSet}});
     }
 
 }


### PR DESCRIPTION
## Proposed Changes

  - Add functionality to visualize a feature set clicking the button of singular feature set in the table of feature set list.
  - Pass the data to the visualization component.
  - Display the current data of the feature set.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #79 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enabled the update button in the list of feature sets, this button now redirect to `onSelectFeatureSet(selectedFeatureSet)` method.
- In the onSelectFeatureSet(selectedFeatureSet) method, the component redirect to "_/fsdetails_" and passing the object of the feature set using `router.navigate` .
- The component redirect to "/fsdetails" but is using the **FeatureSetCreationComponent**, for this I added in the app-route component another direction, now there are 2 urls to redirect to **FeatureSetCreationComponent**.
- On **FeatureSetCreationComponent**, the `ngOnInit()` component checks if is a new feature set or is an existent to edit, there checks with an if conditional if `history.state.selectedFeatureSet` exists, if exists, fill the form fields and the table with the variables.
