### PR TITLE
92 show canonical variables model

### DIFF
--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -174,15 +174,12 @@ export class DataSetCreationComponent implements OnInit {
   }
 
   saveNewDataSet(): void {
-
-    console.log('guardar nuevo data set: ', this.newDataSet);
     Object.keys(this.formGroup1.controls).forEach(key => {
       this.newDataSet[key] = this.formGroup1.get(key).value;
     });
     // this is a mock of created_by of data set, it will be removed.
     this.newDataSet['created_by'] = '1903';
     this.backendService.saveDataSet(this.newDataSet.project_id, this.newDataSet).subscribe(data => {
-      console.log(data);
       this.userCommunication.createMessage('snack-bar-success', 'Data set "' + data.name + '" created successfully')
     });
   }
@@ -191,11 +188,8 @@ export class DataSetCreationComponent implements OnInit {
     Object.keys(this.formGroup1.controls).forEach(key => {
       this.newDataSet[key] = this.formGroup1.get(key).value;
     });
-    console.log('datos actualizados en el componente: ', this.newDataSet);
-    console.log('actualizar data set');
     this.backendService.updateDataSet(this.newDataSet.project_id, this.newDataSet).subscribe( data => {
-      console.log('DATA', data);
-        this.userCommunication.createMessage('snack-bar-success', 'Data set "' + data + '" created successfully')
+      this.userCommunication.createMessage('snack-bar-success', 'Data set "' + data + '" created successfully')
     });
   }
 

--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -75,6 +75,32 @@
       <form [formGroup]="formGroup3">
         <ng-template matStepLabel>Categorial variables</ng-template>
 
+        <table mat-table [dataSource]="categorigalVariablesDataSource" class="mat-elevation-z8">
+
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef> Name </th>
+            <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="fhir_path">
+            <th mat-header-cell *matHeaderCellDef> FHIR path </th>
+            <td mat-cell *matCellDef="let element"> {{element.fhir_path}} </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="fhir_query">
+            <th mat-header-cell *matHeaderCellDef> FHIR query </th>
+            <td mat-cell *matCellDef="let element"> {{element.fhir_query}} </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="variable_type">
+            <th mat-header-cell *matHeaderCellDef> Type </th>
+            <td mat-cell *matCellDef="let element"> {{element.variable_type}} </td>
+          </ng-container>
+        
+          <tr mat-header-row *matHeaderRowDef="categorialVariablesColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: categorialVariablesColumns;"></tr>
+        </table>
+
         <div>
           <button mat-button matStepperPrevious>Back</button>
           <button mat-button matStepperNext>Next</button>

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -45,6 +45,9 @@ export class ModelCreationComponent implements OnInit {
   datasetSelectionDisplayedColumns: string[] = ['name', 'description', 'data_sources', 'created_by', 'creation_time', 'details'];
   datasetSelectionDataSource;
 
+  categorialVariablesColumns: string[] = ['name', 'fhir_path', 'fhir_query', 'variable_type'];
+  categorigalVariablesDataSource;
+
   componentDirection: string;
 
   constructor(
@@ -110,10 +113,20 @@ export class ModelCreationComponent implements OnInit {
       this.newDMModel = data;
       this.formGroup1.get('name').setValue(this.newDMModel.name);
       this.formGroup1.get('description').setValue(this.newDMModel.description);
+      this.getCategorialVariables();
     });
   }
 
   getModel(model): any {
     return of(model);
+  }
+
+  getCategorialVariables(): void {
+    this.categorigalVariablesDataSource = [];
+    this.newDMModel.variable_configurations.forEach(element => {
+      if (element.variable.variable_data_type === 'categorical') {
+        this.categorigalVariablesDataSource.push(element.variable);
+      }
+    });
   }
 }


### PR DESCRIPTION
## Proposed Changes

  - Show the table in the 3st step (Categorical variables) of the Model management
  - The table will show The canonical variables.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

The form of new/update is not completed, the 3st step - **Categorial variables**, need a table to show the canonoical variables.

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #92 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user clicks on the **show** button, the form is filled with the selected **Model** information.
- In the 3st step (Categorial Variables) was added a table to show the canonical variables.
- The data of the table is extracted from the **Model** object hosted in the `newDModel` variable.
- Created a new method called `getCategoricalVariables()`, this method extract the variables from the **Model** object and pass it to the `categoricalVariablesDataSource`, and this is used to fill the table.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
