### PR TITLE
Display table of missing data in Model form

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -160,7 +160,7 @@ import { NewVariableDialogComponent } from './feature-set-creation/new-variable-
     MatTooltipModule,
 
     AppRoutingModule,
-    HttpClientModule
+    HttpClientModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/model-creation/model-creation.component.css
+++ b/src/app/model-creation/model-creation.component.css
@@ -3,6 +3,29 @@ input, mat-form-field {
   width: 100%;
 }
 
+.operation-input {
+  width: 50%;
+  height: 2em;
+  border-radius: 3px;
+  border: #878b88 1px solid;
+  text-align: center;
+}
+
+.select-operation{
+  width: 60%;
+  height: 2em;
+  border-radius: 3px;
+  border: #878b88 1px solid;
+}
+
+.operation-column{
+  width: 30%;
+}
+
+.value-column {
+  width: 10%;
+}
+
 table {
   width: 100%;
 }

--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -111,9 +111,47 @@
       <form [formGroup]="formGroup4">
         <ng-template matStepLabel>Missing Data</ng-template>
 
+        <table mat-table [dataSource]="missingDataDataSource" class="mat-elevation-z8">
+
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef> Variable name </th>
+            <td mat-cell *matCellDef="let element"> {{element.variable.name}} </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="variable_type">
+            <th mat-header-cell *matHeaderCellDef> Type </th>
+            <td mat-cell *matCellDef="let element"> {{element.encoding_type}} </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="operation">
+            <th mat-header-cell *matHeaderCellDef class="operation-column"> Operation </th>
+            <td mat-cell *matCellDef="let element"> 
+              <mat-select [value]="element.missing_data_operation" name="operations" class="select-operation" (selectionChange)="saveOperations($event.value, element)">
+                <mat-option *ngFor="let op of operations" [value]="op.value">
+                  {{op.viewValue}}
+                </mat-option>
+              </mat-select>
+              </td>
+          </ng-container>
+        
+          <ng-container matColumnDef="value">
+            <th mat-header-cell *matHeaderCellDef class="value-column"> Value </th>
+            <td mat-cell *matCellDef="let element"> 
+                <input  *ngIf="element.missing_data_operation === 'set_specific'" 
+                      [value]="element.missing_data_specific_value" 
+                      class="operation-input"
+                      #operator_value
+                      (change)="specificValueChange(operator_value, element)">
+            </td>
+          </ng-container>
+        
+          <tr mat-header-row *matHeaderRowDef="missingDataColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: missingDataColumns;"></tr>
+        </table>
+
         <div>
           <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button mat-button matStepperNext >Next</button>
         </div>
       </form>
     </mat-step>

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -17,7 +17,7 @@
  */
 
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { LocalStorageService } from '../core/services/local-storage.service';
 
 import { BackendService } from '../core/services/backend.service';
@@ -47,6 +47,18 @@ export class ModelCreationComponent implements OnInit {
 
   categorialVariablesColumns: string[] = ['name', 'fhir_path', 'fhir_query', 'variable_type'];
   categorigalVariablesDataSource;
+
+  missingDataColumns: string[] = ['name', 'variable_type', 'operation', 'value'];
+  missingDataDataSource;
+  operations: any[] = [
+    {value: 'set_minimum', viewValue: 'Set minimum'},
+    {value: 'set_maximum', viewValue: 'Set maximun'},
+    {value: 'set_average', viewValue: 'Set average'},
+    {value: 'set_mean', viewValue: 'Set mean'},
+    {value: 'set_median', viewValue: 'Set median'},
+    {value: 'set_specific', viewValue: 'Set specific'},
+  ];
+  selectedOperation;
 
   componentDirection: string;
 
@@ -80,7 +92,8 @@ export class ModelCreationComponent implements OnInit {
       formGroup3: ['', Validators.required]
     });
     this.formGroup4 = this.formBuilder.group({
-      formGroup4: ['', Validators.required]
+      // formGroup4: ['', Validators.required]
+      missing_data_operation: ['']
     });
     this.formGroup5 = this.formBuilder.group({
       formGroup5: ['', Validators.required]
@@ -114,6 +127,7 @@ export class ModelCreationComponent implements OnInit {
       this.formGroup1.get('name').setValue(this.newDMModel.name);
       this.formGroup1.get('description').setValue(this.newDMModel.description);
       this.getCategorialVariables();
+      this.getMissingData();
     });
   }
 
@@ -128,5 +142,27 @@ export class ModelCreationComponent implements OnInit {
         this.categorigalVariablesDataSource.push(element.variable);
       }
     });
+  }
+
+  getMissingData(): void {
+    this.missingDataDataSource = [];
+    this.newDMModel.variable_configurations.forEach(element => {
+      this.missingDataDataSource.push(element);
+    });
+  }
+
+  saveOperations(operator, element): void {
+
+    element.missing_data_operation = operator;
+
+    if (operator === 'set_specific') {
+      element.missing_data_specific_value = '0';
+    } else {
+      delete element.missing_data_specific_value;
+    }
+  }
+
+  specificValueChange(opValue, element): void {
+    element.missing_data_specific_value = opValue.value;
   }
 }


### PR DESCRIPTION
## Proposed Changes
 Add table to the 4th section of the for of Data Model.
  - The table should have 4 columns: variable name, type, operation and value.
  - The operation columns, the values can be changed with a dropdown
  - If the operator is  "Set specific" the value column will deploy a input to set a value.
  - Add new registries.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

This table don't exist.

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #99 

## What is the new behavior?

- The added table have data from `variable_configurations` Data Model property, and this data is showed in the table in 4 columns:

**Variable name**: variable_configurations.variable.name.
**Type**: variable_configurations.encoding_type
**Operation**: variable_configurations.missing_data_operation
**Value**: variable_configurations.missing_data_specific_value

- The table columns are specificated in `missingDataColumns`, and the data source in `missingDataDataSource`.

- Extract the data: the data is extracted from a existent Model, and the method that manage this task is `getMissingData()`, this method get the data from `this.newDMModel.variable_configurations`.

- In **"Operation"** column there are drop-downs, in this dropdowns are the diferent operators that the user can choose, this options are in `operations` variable.

- If the user choose the "Set specific" operator, in the Value column will appear a input form that the user can set a value, if is another operator the input will disapear.

- The selection of a operator is automatically changed in the object using the saveOperations() method, this method receives the selected operator and the element where the operator will be added.

- When the user sets a value in the inputs, also is added automatically to the Model object, but if in the same row, the user change the operator from "Set specific" to any of the other options, the `missing_data_specific_value` will desapear from the element.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Is not possible to add new registries, in the next Feature,  this function could be added.
