### PR TITLE
dissable form fields when see details.

### DIFF
--- a/src/app/data-set-creation/data-set-creation.component.css
+++ b/src/app/data-set-creation/data-set-creation.component.css
@@ -14,3 +14,7 @@ table {
 .querying {
   color: darkorange;
 }
+
+.mat-input-element:disabled {
+  color: black;
+}

--- a/src/app/data-set-creation/data-set-creation.component.html
+++ b/src/app/data-set-creation/data-set-creation.component.html
@@ -38,7 +38,7 @@
               <th mat-header-cell *matHeaderCellDef>
               </th>
               <td mat-cell *matCellDef="let row">
-                <mat-radio-button [value]="row"></mat-radio-button>
+                <mat-radio-button [value]="row" [disabled]="isDisabled"></mat-radio-button>
               </td>
             </ng-container>
 
@@ -106,7 +106,7 @@
               <input matInput placeholder="Path" [(ngModel)]='newElegibilityCriteria.fhir_path' formControlName="formGroup3">
             </mat-form-field>
             <div>
-              <button mat-button (click)="onAddElegibilityCriteria()"><mat-icon>playlist_add</mat-icon></button>
+              <button mat-button (click)="onAddElegibilityCriteria()" [disabled]="isDisabled"><mat-icon>playlist_add</mat-icon></button>
               <br>
               <br>
             </div>
@@ -211,8 +211,8 @@
 
         <div>
           <button mat-button matStepperPrevious color="primary" >Back</button>
-          <button mat-button (click) ="stepper.reset()" color="primary" >Reset</button>
-          <button mat-button (click) ="onSaveDataSet()" color="primary" >Save</button>
+          <button mat-button (click) ="stepper.reset()" color="primary" [disabled]="isDisabled">Reset</button>
+          <button mat-button (click) ="onSaveDataSet()" color="primary" [disabled]="isDisabled">Save</button>
         </div>
       </form>
     </mat-step>

--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -55,6 +55,8 @@ export class DataSetCreationComponent implements OnInit {
 
   componentDirection: string;
 
+  isDisabled: boolean;
+
   constructor(
     private formBuilder: FormBuilder,
     private backendService: BackendService,
@@ -91,8 +93,12 @@ export class DataSetCreationComponent implements OnInit {
 
     if (history.state.selectedDataSet) {
         this.componentDirection = 'Data set edition';
+        this.isDisabled = true;
+        this.formGroup1.disable();
+        this.formGroup3.disable();
         this.onSeeDataSet();
     } else {
+      this.isDisabled = false;
       this.componentDirection = 'Data set creation';
     }
   }
@@ -164,7 +170,7 @@ export class DataSetCreationComponent implements OnInit {
 
   onSaveDataSet(): void {
     if (history.state.selectedDataSet) {
-      this.updateDataSet();
+    //  this.updateDataSet();
     } else {
       this.saveNewDataSet();
     }

--- a/src/app/feature-set-creation/feature-set-creation.component.css
+++ b/src/app/feature-set-creation/feature-set-creation.component.css
@@ -3,6 +3,16 @@ input, mat-form-field {
   width: 100%;
 }
 
+.mat-input-element:disabled {
+  color: black;
+}
+
+/*
+.mat-select-disabled .mat-select-value {
+  color: rgba(black, 0.38);
+}
+*/
+
 table {
   width: 100%;
 }

--- a/src/app/feature-set-creation/feature-set-creation.component.html
+++ b/src/app/feature-set-creation/feature-set-creation.component.html
@@ -8,17 +8,17 @@
 
   <mat-form-field appearance="fill">
     <mat-label>Feature set name</mat-label>
-    <input matInput ngDefaultControl [(ngModel)]='name'>
+    <input matInput ngDefaultControl [(ngModel)]='name' [disabled]="isDisabled">
   </mat-form-field>
   <br>
   <mat-form-field appearance="fill">
     <mat-label>Description</mat-label>
-    <input matInput ngDefaultControl [(ngModel)]='description'>
+    <input matInput ngDefaultControl [(ngModel)]='description' [disabled]="isDisabled">
   </mat-form-field>
 
   <br>
 
-  <button mat-raised-button (click)='onNewVariable()'>Add new variable</button>
+  <button mat-raised-button (click)='onNewVariable()' [disabled]="isDisabled">Add new variable</button>
 
   <br>
   <br>
@@ -73,6 +73,7 @@
   <br>
   <br>
 
-  <button mat-raised-button color="primary" (click)="onSave()">Save</button> &nbsp;&nbsp; <button mat-raised-button color="warn" (click)="onCancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onSave()" [disabled]="isDisabled">Save</button> &nbsp;&nbsp; 
+  <button mat-raised-button color="warn" (click)="onCancel()">Cancel</button>
 
 </div>

--- a/src/app/feature-set-creation/feature-set-creation.component.ts
+++ b/src/app/feature-set-creation/feature-set-creation.component.ts
@@ -42,6 +42,7 @@ export class FeatureSetCreationComponent implements OnInit {
   newVariable: Variable;
   componentTitle: string;
   componentDirection: string;
+  isDisabled: boolean;
 
   @ViewChild(MatTable) table: MatTable<any>;
   displayedColumns: string[] = ['name', 'description', 'variable_type', 'variable_data_type', 'fhir_query', 'fhir_path', 'delete'];
@@ -59,9 +60,11 @@ export class FeatureSetCreationComponent implements OnInit {
 
     if (history.state.selectedFeatureSet) {
       this.fillFields();
+      this.isDisabled = true;
       this.componentTitle = 'Edit feature set';
       this.componentDirection = 'Feature set edition';
     } else {
+      this.isDisabled = false;
       this.componentTitle = 'Create a new feature set';
       this.componentDirection = 'Feature set creation';
     }
@@ -69,6 +72,7 @@ export class FeatureSetCreationComponent implements OnInit {
   }
 
   fillFields(): void {
+
     this.name = history.state.selectedFeatureSet.name;
     this.description = history.state.selectedFeatureSet.description ;
     this.dataSource = history.state.selectedFeatureSet.variables;

--- a/src/app/model-creation/model-creation.component.css
+++ b/src/app/model-creation/model-creation.component.css
@@ -29,3 +29,7 @@ input, mat-form-field {
 table {
   width: 100%;
 }
+
+.mat-input-element:disabled {
+  color: black;
+}

--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -45,7 +45,7 @@
               <th mat-header-cell *matHeaderCellDef>
               </th>
               <td mat-cell *matCellDef="let row">
-                <mat-radio-button [value]="row" (change)="selectDataSet(row)"></mat-radio-button>
+                <mat-radio-button [value]="row" (change)="selectDataSet(row)" [disabled]="isDisabled"></mat-radio-button>
               </td>
             </ng-container>
 
@@ -138,8 +138,8 @@
           <ng-container matColumnDef="operation">
             <th mat-header-cell *matHeaderCellDef class="operation-column"> Operation </th>
             <td mat-cell *matCellDef="let element"> 
-              <mat-select [value]="element.missing_data_operation" name="operations" class="select-operation" (selectionChange)="saveOperations($event.value, element)">
-                <mat-option *ngFor="let op of operations" [value]="op.value">
+              <mat-select [value]="element.missing_data_operation" name="operations" [disabled]="isDisabled" class="select-operation" (selectionChange)="saveOperations($event.value, element)">
+                <mat-option *ngFor="let op of operations" [value]="op.value" >
                   {{op.viewValue}}
                 </mat-option>
               </mat-select>
@@ -153,7 +153,8 @@
                       [value]="element.missing_data_specific_value" 
                       class="operation-input"
                       #operator_value
-                      (change)="specificValueChange(operator_value, element)">
+                      (change)="specificValueChange(operator_value, element)"
+                      [disabled]="isDisabled">
             </td>
           </ng-container>
         

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -64,6 +64,7 @@ export class ModelCreationComponent implements OnInit {
 
   componentDirection: string;
   featureSetVariables;
+  isDisabled: boolean;
 
   constructor(
     private backendService: BackendService,
@@ -106,8 +107,11 @@ export class ModelCreationComponent implements OnInit {
     });
     if (history.state.selectedModel) {
       this.onSeeModel();
+      this.formGroup1.disable();
+      this.isDisabled = true;
       this.componentDirection = 'Model edition';
     } else {
+      this.isDisabled = false;
       this.componentDirection = 'Model creation';
     }
   }


### PR DESCRIPTION
## Proposed Changes
  - Disable the form fields of the diferents use cases when the user go to "See details"

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #106 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

### Feature sets:
-  Disabled the text fields of **Name** and **Description**.
- Disabled **Save** button.
- Disable **Add new variable**
- Print the text fields in black, the disabled of the fields put the text in gray color.

### Data sets:

- Disabled the fields of **Name and description**, **Feature set selection**  and **Elegibility criteria** sections.
- Disabled the **Save** and **Reset** buttons.
- Disabled the `updateDataSet()` method.

### Models:

- Disabled the **Name and description**, **Data set selection** and **Missing data** fields sections.

### Technic details:

- In all components created the isDisabled variable, this variable if the objects exists, is true.
- The `isDisabled` variable is used in some fields putting `[disabled]="isDisabled"` inside the tag.
- Some fields only can be disabled using the `.disabled()` method of **FormBuilder**

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
