### PR TITLE
enable to open use case menu of prediction type use cases

### DIFF
--- a/src/app/use-case-list/use-case-list.component.ts
+++ b/src/app/use-case-list/use-case-list.component.ts
@@ -69,9 +69,8 @@ export class UseCaseListComponent implements OnInit {
       this.localStorage.setProjectId(useCaseSelected.project_id);
       this.router.navigate(['/ucmenu']);
     } else if (useCaseSelected.project_type === 'prediction') {
-      console.log('Prediction use case selected!');
-      // TO DO prediction use case navigation
-      this.userCommunication.createMessage(this.userCommunication.INFO, 'Prediction use case is not supported yet');
+      this.localStorage.setProjectId(useCaseSelected.project_id);
+      this.router.navigate(['/ucmenu']);
     } else {
       console.log('Project type does not match association nor prediction');
       this.userCommunication.createMessage(this.userCommunication.ERROR, 'Project type does not match association nor prediction');

--- a/src/app/use-case-menu/use-case-menu.component.css
+++ b/src/app/use-case-menu/use-case-menu.component.css
@@ -1,5 +1,10 @@
 .featuremanagement-card {
   max-width: 400px;
+ 
+}
+
+.data-card {
+  margin-bottom: 20px;
 }
 
 .dataSetmanagement-card {
@@ -7,6 +12,16 @@
 }
 
 .modelmanagement-card {
+  max-width: 400px;
+}
+
+.predictive-study-card{
+  max-width: 400px;
+}
+
+.predictive-study-card-header {
+  background-color: #6db044;
+  color: white;
   max-width: 400px;
 }
 
@@ -32,6 +47,9 @@
   background-color: chocolate;
 }
 
+.featuremanagement-card-buttom {
+  background-color: #6db044;
+}
 
 .modelmanagement-buttom {
   background-color: darkslateblue;
@@ -55,4 +73,8 @@ mat-grid-tile mat-card{
 .use-case-header {
   border: 1px dotted grey;
   padding: 4px;
+}
+
+mat-grid-tile{
+  margin-bottom: 10px !important;
 }

--- a/src/app/use-case-menu/use-case-menu.component.html
+++ b/src/app/use-case-menu/use-case-menu.component.html
@@ -12,9 +12,9 @@
 
 <br>
 
-<mat-grid-list cols="3" rowHeight="250px">
+  <mat-grid-list [cols]="cols" rowHeight="250px">
   <mat-grid-tile>
-    <mat-card class="featuremanagement-card">
+    <mat-card class="featuremanagement-card data-card">
       <mat-card-header class="featuremanagement-card-header">
         <mat-card-title>Feature Set Management</mat-card-title>
       </mat-card-header>
@@ -31,8 +31,9 @@
       </mat-card-actions>
     </mat-card>
   </mat-grid-tile>
+  <br>
   <mat-grid-tile>
-    <mat-card class="dataSetmanagement-card">
+    <mat-card class="dataSetmanagement-card data-card">
       <mat-card-header class="dataSetmanagement-card-header">
         <mat-card-title>Data Set Management</mat-card-title>
       </mat-card-header>
@@ -49,8 +50,9 @@
       </mat-card-actions>
     </mat-card>
   </mat-grid-tile>
+  <br>
   <mat-grid-tile>
-    <mat-card class="modelmanagement-card">
+    <mat-card class="modelmanagement-card data-card">
       <mat-card-header class="modelmanagement-card-header">
         <mat-card-title>Model management</mat-card-title>
       </mat-card-header>
@@ -61,6 +63,25 @@
       </mat-card-content>
       <mat-card-actions>
         <button mat-raised-button color="primary" class="modelmanagement-buttom" (click)="onModelMgmt()">Select</button>
+      </mat-card-actions>
+    </mat-card>
+  </mat-grid-tile>
+  <br>
+  <mat-grid-tile>
+    <mat-card class="predictive-study-card data-card data-card" *ngIf="useCaseType === 'prediction'">
+      <mat-card-header class="predictive-study-card-header">
+        <mat-card-title>Prospective Study</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <p>Feature set is like an empty Excel template. </p>
+        <mat-divider></mat-divider>
+        <p>Create your feature set template by specifying FHIR Queries and FHOR Paths.</p>
+        <mat-divider></mat-divider>
+        <p>Use later it on creating your data set.</p>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" class="featuremanagement-card-buttom"
+          (click)="onProspectiveStudy()">Select</button>
       </mat-card-actions>
     </mat-card>
   </mat-grid-tile>

--- a/src/app/use-case-menu/use-case-menu.component.ts
+++ b/src/app/use-case-menu/use-case-menu.component.ts
@@ -34,6 +34,8 @@ export class UseCaseMenuComponent implements OnInit {
 
   useCaseSelectedId: string;
   useCase: UseCase;
+  useCaseType: string;
+  cols: number;
 
   constructor(
     private route: ActivatedRoute,
@@ -57,9 +59,17 @@ export class UseCaseMenuComponent implements OnInit {
         // Array check to work with real service and mock service
         if (Array.isArray(usecase)) {
           this.useCase = usecase[0];
+          this.useCaseType = usecase[0].project_type;
         } else {
           this.useCase = usecase;
+          this.useCaseType = usecase.project_type;
         }
+        if (this.useCaseType === 'prediction') {
+          this.cols = 2;
+        }else if (this.useCaseType === 'association') {
+          this.cols = 3;
+        }
+
         this.localStorage.setProjectId(this.useCaseSelectedId);
       },
       (err) => {
@@ -81,5 +91,10 @@ export class UseCaseMenuComponent implements OnInit {
   onModelMgmt(): void {
     console.log('Model management');
     this.router.navigate(['/mdashboard']);
+  }
+
+  onProspectiveStudy(): void {
+    console.log('Prospective study selected');
+    this.userCommunication.createMessage(this.userCommunication.INFO, 'Prediction Study is not supported yet');
   }
 }


### PR DESCRIPTION
## Proposed Changes
  
  - Select predixtion type uses case.
  - Create the Prospective Stydy panel if the uses case is of type prediction.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #41 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enable the select button in "prediction type" use cases. in `onUsesCase()` if project_type is equals "_prediction_", navigates to the uses **case menu** component
- In use case menu component, created 2 new variables: `useCaseType` and `cols`. `useCaseType` is used to define if the panel of Prospective Study will be displayed, and `cols` define in how many columns the panels is displayed (3 if not a "prediction" and 2 if it is).
- Created the new panle for Prospective Study if the  use case is "_prediction_".
- Defined the CSS classes for decorate the new panel.
