### PR TITLE
152 dataset selection status

### DIFF
--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -171,7 +171,7 @@ export class DataSetCreationComponent implements OnInit {
         }
       });
       data.dataset_sources.forEach(element => {
-        if (element.selection_status === '') {
+        if (element.selection_status === '' || !element.selection_status) {
           element.selection_status = 'discarded';
         }
       });

--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -170,6 +170,11 @@ export class DataSetCreationComponent implements OnInit {
           this.completedData.push(element);
         }
       });
+      data.dataset_sources.forEach(element => {
+        if (element.selection_status === '') {
+          element.selection_status = 'discarded';
+        }
+      });
 
       this.completeddataTable = new MatTableDataSource(this.completedData);
       this.getDataSource(data.dataset_sources);

--- a/src/app/prospective-study-creation/prospective-study-creation.component.ts
+++ b/src/app/prospective-study-creation/prospective-study-creation.component.ts
@@ -127,6 +127,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
         };
         this.variables.variables = [];
         this.variables.data_mining_model = this.selectedModel;
+        this.variables['submitted_by'] = '1903';
 
         Object.keys(this.formGroup3.controls).forEach(key => {
 
@@ -254,7 +255,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
 
             this.variables.identifier = '1';
             this.variables.data_mining_model = this.selectedModel;
-
+            this.variables['submitted_by'] = '1903';
             this.backendService.predict(this.variables).subscribe(
               data => {
                 this.patientsPredictions[i].prediction = data.prediction;


### PR DESCRIPTION
## Proposed Changes

  - Set the selection status of agents in in data set to "discarded" if this status is empty or null.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->

The selection status of agents of a data sets are not defined at the first time, this make errors.

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #152 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user selects to edit a data set, the component check if the selection status of a agent exists or is empty, in the case that comply one of this conditions, the component will asignee the value "**discarded**" to `selection_status`.
- ⚠️ The application don't save this modification in the Data set, exept if the user saves the changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
