### PR TITLE
Change Cancel button of feature set to Close when is already created

### DIFF
--- a/src/app/feature-set-creation/feature-set-creation.component.html
+++ b/src/app/feature-set-creation/feature-set-creation.component.html
@@ -77,6 +77,7 @@
   <br>
 
   <button mat-raised-button color="primary" (click)="onSave()" [disabled]="isDisabled">Save</button> &nbsp;&nbsp; 
-  <button mat-raised-button color="warn" (click)="onCancel()">Cancel</button>
+  <button *ngIf="! isDisabled" mat-raised-button color="warn" (click)="onCancel()">Cancel</button>
+  <button *ngIf="isDisabled" mat-raised-button color="warn" (click)="onCancel()">Close</button>
 
 </div>


### PR DESCRIPTION
## Proposed Changes

  - Change the button text when the user selects to see a created feature set to "Back"

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #166 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed the button from "Cancel" to "Close" when the Feature set is created.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
