### PR TITLE
get the id of the user and used in created_by when the app saves data

### DIFF
--- a/src/app/core/services/local-storage.service.ts
+++ b/src/app/core/services/local-storage.service.ts
@@ -26,6 +26,7 @@ export class LocalStorageService {
   projectId: string;
   projectName: string;
   projectType: string;
+  userId: string;
 
   constructor() { }
 
@@ -41,6 +42,10 @@ export class LocalStorageService {
 
   setProjectType(projectType): void {
     this.projectType = projectType;
+  }
+
+  setUserId(id: string): void {
+    this.userId = id;
   }
 
   reset(): void {

--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -219,7 +219,7 @@ export class DataSetCreationComponent implements OnInit {
       this.newDataSet[key] = this.formGroup1.get(key).value;
     });
     // this is a mock of created_by of data set, it will be removed.
-    this.newDataSet['created_by'] = '1903';
+    this.newDataSet['created_by'] = this.localStorage.userId;
     this.backendService.saveDataSet(this.newDataSet.project_id, this.newDataSet).subscribe(data => {
       this.getDataSource(data.dataset_sources);
       this.userCommunication.createMessage('snack-bar-success', 'Data set "' + data.name + '" created successfully')

--- a/src/app/feature-set-creation/feature-set-creation.component.ts
+++ b/src/app/feature-set-creation/feature-set-creation.component.ts
@@ -117,7 +117,7 @@ export class FeatureSetCreationComponent implements OnInit {
     if (history.state.selectedFeatureSet) {
       console.log('Update existent feature set.');
     } else {
-      newFeatureSet['created_by'] = '1903';
+      newFeatureSet['created_by'] = this.localStorage.userId;
       this.backendService.saveFeatureSet(newFeatureSet).subscribe(
         (data) => {
           console.log('New feature set creation answer received! ', data);

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -25,6 +25,7 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { LogoutDialogComponent } from './logout-dialog/logout-dialog.component';
 import { KeycloakService } from 'keycloak-angular';
+import { LocalStorageService } from '../core/services/local-storage.service';
 
 
 @Component({
@@ -39,12 +40,14 @@ export class HeaderComponent implements OnInit {
     private userCommunication: UserCommunicationService,
     private router: Router,
     public dialog: MatDialog,
-    protected keycloakAngular: KeycloakService
+    protected keycloakAngular: KeycloakService,
+    private localStorage: LocalStorageService
     ) { }
 
   ngOnInit(): void {
     try {
       console.log('update logged user details');
+      this.localStorage.setUserId(this.keycloakAngular.getKeycloakInstance().tokenParsed['sub']);
       this.auth.login(this.keycloakAngular.getKeycloakInstance().tokenParsed['name'],
       this.keycloakAngular.getKeycloakInstance().token,
       this.keycloakAngular.getKeycloakInstance().realmAccess.roles[0]);

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -263,7 +263,7 @@ export class ModelCreationComponent implements OnInit {
     this.newDMModel.dataset = this.formGroup2.get('dataset').value;
     this.newDMModel.algorithms = [];
     this.newDMModel.algorithms = this.algorithmsList;
-    this.newDMModel.created_by = '1903';
+    this.newDMModel.created_by = this.localStorage.userId;
     this.newDMModel.project_id = this.localStorage.projectId;
     this.newDMModel.training_size = this.formGroup6.get('training_size').value / 100;
     this.newDMModel.test_size = this.formGroup6.get('test_size').value / 100;

--- a/src/app/prospective-study-creation/prospective-study-creation.component.ts
+++ b/src/app/prospective-study-creation/prospective-study-creation.component.ts
@@ -141,7 +141,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
         };
         this.variables.variables = [];
         this.variables.data_mining_model = this.selectedModel;
-        this.variables.submitted_by = '1903'; // change on actual user later.
+        this.variables.submitted_by = this.localStorage.userId;
 
         Object.keys(this.formGroup3.controls).forEach(key => {
 
@@ -152,7 +152,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
             };
 
             this.variable.name = key;
-            this.variables.submitted_by = '1903';
+            this.variables.submitted_by = this.localStorage.userId;
             this.variable.value = this.formGroup3.get(key).value;
             this.variablesDataSet.forEach(el => {
               if (el.name === key) {
@@ -195,7 +195,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
       this.prospectiveStudy.data_mining_model = this.selectedModel;
       this.prospectiveStudy.name = this.formGroup1.get('name').value;
       this.prospectiveStudy.description = this.formGroup1.get('description').value;
-      this.prospectiveStudy.created_by = '1903';
+      this.prospectiveStudy.created_by = this.localStorage.userId;
       this.prospectiveStudy.predictions = this.predictionList;
       this.prospectiveStudy.project_id = this.projectId;
 
@@ -271,7 +271,7 @@ export class ProspectiveStudyCreationComponent implements OnInit {
 
             this.variables.identifier = '1';
             this.variables.data_mining_model = this.selectedModel;
-            this.variables.submitted_by = '1903'; // change on actual user later.
+            this.variables.submitted_by = this.localStorage.userId;
             this.backendService.predict(this.variables).subscribe(
               data => {
                 this.patientsPredictions[i].prediction = data.prediction;

--- a/src/app/usecase-creation/usecase-creation.component.ts
+++ b/src/app/usecase-creation/usecase-creation.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BackendService } from '../core/services/backend.service';
+import { LocalStorageService } from '../core/services/local-storage.service';
 import { UserCommunicationService } from '../core/services/user-communication.service';
 import { UseCase } from '../shared/use-case';
 
@@ -15,7 +16,8 @@ export class UseCaseCreationComponent implements OnInit {
   constructor(private router: Router,
               private formBuilder: FormBuilder,
               private service: BackendService,
-              private userCommunication: UserCommunicationService
+              private userCommunication: UserCommunicationService,
+              private localStorage: LocalStorageService
               ) { }
 
   formGroup1: FormGroup;
@@ -43,7 +45,7 @@ export class UseCaseCreationComponent implements OnInit {
       newUseCase[key] = this.useCaseForm.get(key).value;
     });
 
-    newUseCase.created_by = '1903';
+    newUseCase.created_by = this.localStorage.userId;
 
     this.service.saveUseCase(newUseCase).subscribe(
       (useCase) => {


### PR DESCRIPTION
## Proposed Changes

  - Get the id of the user.
  - Use this id when "created_by" is required.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #148 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Get the ID of the logged user from keyloack.
- Use this id when the "created_by" is required to save data.
- Used in:
    - **DataSetCreationComponent** ▶️  `saveNewDataSet()`.
    - **FeatureSetCreationComponent** ▶️ `onSave()`.
    - **ModelCreationComponent**  ▶️  `onSave()`.
    - **ProspectiveStudyComponent**  ▶️  used for make the predictions and is stored in `submitted_by`, also used in `created_by` to save the prediction.
    - **UseCaseComponent**  ▶️ `onSave()`.
- Created in the **LocalStorageService** the variable `userId` to storage this user ID and use arround the applicaction.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
