### PR TITLE
Change model final table

### DIFF
--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -30,40 +30,38 @@
     <mat-step [stepControl]="formGroup2">
       <form [formGroup]="formGroup2">
         <ng-template matStepLabel>Data set selection</ng-template>
-          <table mat-table [dataSource]="datasetSelectionDataSource" class="mat-elevation-z8">
+          <table mat-table [dataSource]='datasetSelectionDataSource' class="mat-elevation-z8">
           
             <!-- Radio button Column -->
             <ng-container matColumnDef="select">
               <th mat-header-cell *matHeaderCellDef>
               </th>
               <td mat-cell *matCellDef="let row" >
-                <mat-radio-button [value]="row" (change)="selectDataSet(row)" [disabled]="isDisabled"></mat-radio-button>
+
+                <mat-radio-button [value]="row" *ngIf="row.dataset_id != selectedDataSet.dataset_id" (change)="selectDataSet(row)"></mat-radio-button>
+                <mat-radio-button [value]="row" *ngIf="row.dataset_id === selectedDataSet.dataset_id" checked="true"></mat-radio-button>
               </td>
-            </ng-container>
+            </ng-container> 
 
             <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef> name </th>
+              <th mat-header-cell *matHeaderCellDef> Name </th>
               <td mat-cell *matCellDef="let element"> {{element.name}} </td>
             </ng-container>
             <ng-container matColumnDef="description">
-              <th mat-header-cell *matHeaderCellDef> description </th>
+              <th mat-header-cell *matHeaderCellDef> Description </th>
               <td mat-cell *matCellDef="let element"> {{element.description}} </td>
             </ng-container>
             <ng-container matColumnDef="data_sources">
-              <th mat-header-cell *matHeaderCellDef> data_sources </th>
-              <td mat-cell *matCellDef="let element"> {{element.data_sources}} </td>
+              <th mat-header-cell *matHeaderCellDef> Agents </th>
+              <td mat-cell *matCellDef="let element"> {{element.dataset_sources.length}} </td>
+            </ng-container>
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef> Status </th>
+              <td mat-cell *matCellDef="let element"> {{element.execution_state}} </td>
             </ng-container>
             <ng-container matColumnDef="created_by">
-              <th mat-header-cell *matHeaderCellDef> created_by </th>
+              <th mat-header-cell *matHeaderCellDef> Created by </th>
               <td mat-cell *matCellDef="let element"> {{element.created_by}} </td>
-            </ng-container>
-            <ng-container matColumnDef="creation_time">
-              <th mat-header-cell *matHeaderCellDef> creation_time </th>
-              <td mat-cell *matCellDef="let element"> {{element.creation_time}} </td>
-            </ng-container>
-            <ng-container matColumnDef="details">
-              <th mat-header-cell *matHeaderCellDef> details </th>
-              <td mat-cell *matCellDef="let element"> {{element.details}} </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="datasetSelectionDisplayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: datasetSelectionDisplayedColumns;"></tr>

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -26,6 +26,7 @@ import { UserCommunicationService } from '../core/services/user-communication.se
 import { DmModel } from '../shared/dm-model';
 import { Algorithm } from '../shared/algorithm';
 import { Router } from '@angular/router';
+import { MatTableDataSource } from '@angular/material/table';
 
 @Component({
   selector: 'app-model-creation',
@@ -44,8 +45,8 @@ export class ModelCreationComponent implements OnInit {
   newDMModel: DmModel;
   selectedDatasetRow;
 
-  datasetSelectionDisplayedColumns: string[] = ['select', 'name', 'description', 'data_sources', 'created_by', 'creation_time', 'details'];
-  datasetSelectionDataSource;
+  datasetSelectionDisplayedColumns: string[] = ['select', 'name', 'description', 'data_sources', 'status', 'created_by'];
+  datasetSelectionDataSource = new MatTableDataSource();
 
   categorialVariablesColumns: string[] = ['name', 'fhir_path', 'fhir_query', 'variable_type'];
   categorigalVariablesDataSource;
@@ -68,6 +69,7 @@ export class ModelCreationComponent implements OnInit {
   selectedAlgorithm = new Algorithm();
   usecaseType: string;
   useCaseName: string;
+  selectedDataSet: any;
 
   algorithmParameterForm: any = [];
   algorithmsList: any = [];
@@ -136,13 +138,22 @@ export class ModelCreationComponent implements OnInit {
 
     this.getUseCaseType(this.localStorage.projectId);
     this.getAlgoritms();
-   
   }
 
   getDataSets(): void {
+
+    const dataSets = [];
     this.backendService.getDataSetsList(this.localStorage.projectId).subscribe(
       (datasets) => {
-        this.datasetSelectionDataSource = datasets;
+
+        datasets.forEach(element => {
+          console.log('EXECUTION STATE: ', element.execution_state);
+          if (element.execution_state === 'final') {
+            dataSets.push(element);
+          }
+        });
+
+        this.datasetSelectionDataSource = new MatTableDataSource(dataSets);
 
       },
       (err) => {
@@ -155,7 +166,8 @@ export class ModelCreationComponent implements OnInit {
 
     this.backendService.getModel(history.state.selectedModel.model_id).subscribe(
       data => {
-        console.log('EXISTING MODEL -->', data)
+        console.log('EXISTING MODEL -->', data);
+        this.selectedDataSet = data.dataset;
         this.newDMModel = data;
         this.formGroup1.get('name').setValue(this.newDMModel.name);
         this.formGroup1.get('description').setValue(this.newDMModel.description);

--- a/src/app/model-dashboard/model-dashboard.component.html
+++ b/src/app/model-dashboard/model-dashboard.component.html
@@ -10,7 +10,7 @@
 
 <button mat-raised-button [routerLink]="['/mcreation']">Create new model</button>
 
-<h3>Ready</h3>
+<h3>Final</h3>
 <table mat-table *ngIf="dataSourceReady.length" [dataSource]="dataSourceReady" class="mat-elevation-z8">
 
   <ng-container matColumnDef="name">


### PR DESCRIPTION
## Proposed Changes

 - Changing the name of first section to “Final”, instead of “Ready”
 - Showing only the data mining models whose status is “final” in this section (the data mining models with no algorithm&statistics selected will be shown in “In progress” section)
 - In step two of new model creation where user selects a dataset, filter the datasets and list only the ones whose status is final. In this way, we don’t face with the same problem.
 - Mark as selected the dataset of a created Model.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #179 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed the title of the table of final status, from **ready** to **final**.
- In the dashboard of Models, in the final table, show only the final status Models.
- In the form of creation of Models, in the seconds steps, the table of dataset shows only the final status Datasets.
- In the table of Datasets, will show the selected Data Set if the user selects to se details of a model.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

