### PR TITLE
Dialog confirmation of close the form in feature set

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -97,6 +97,7 @@ import { KeycloakService, KeycloakAngularModule } from 'keycloak-angular';
 import { APP_INITIALIZER } from '@angular/core';
 import { initializer } from './core/services/usermanagement';
 import { FooterComponent } from './footer/footer.component';
+import { DialogConfirmationComponent } from './dialog-confirmation/dialog-confirmation.component';
 
 @NgModule({
   declarations: [
@@ -121,6 +122,7 @@ import { FooterComponent } from './footer/footer.component';
     ProspectiveStudyComponent,
     ProspectiveStudyCreationComponent,
     FooterComponent,
+    DialogConfirmationComponent,
   ],
   imports: [
     CoreModule,

--- a/src/app/dialog-confirmation/dialog-confirmation.component.html
+++ b/src/app/dialog-confirmation/dialog-confirmation.component.html
@@ -1,0 +1,14 @@
+<h1 mat-dialog-title>
+  <mat-icon aria-hidden="false" currentColor="warn">warning_amber</mat-icon>
+
+  {{data.title}}
+</h1>
+<div mat-dialog-content>
+  <p>{{data.message}}</p>
+
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">{{data.cancelButton}}</button>
+  <button mat-button [mat-dialog-close]="data" cdkFocusInitial>{{data.acceptButton}}</button>
+</div>
+

--- a/src/app/dialog-confirmation/dialog-confirmation.component.spec.ts
+++ b/src/app/dialog-confirmation/dialog-confirmation.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DialogConfirmationComponent } from './dialog-confirmation.component';
+
+describe('DialogConfirmationComponent', () => {
+  let component: DialogConfirmationComponent;
+  let fixture: ComponentFixture<DialogConfirmationComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DialogConfirmationComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DialogConfirmationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dialog-confirmation/dialog-confirmation.component.ts
+++ b/src/app/dialog-confirmation/dialog-confirmation.component.ts
@@ -1,0 +1,24 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-dialog-confirmation',
+  templateUrl: './dialog-confirmation.component.html',
+  styleUrls: ['./dialog-confirmation.component.css']
+})
+export class DialogConfirmationComponent implements OnInit {
+
+  // data: the text of the dialog.
+  constructor(
+    public dialogRef: MatDialogRef<DialogConfirmationComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any
+  ) { }
+
+  ngOnInit(): void {
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+}

--- a/src/app/feature-set-creation/feature-set-creation.component.html
+++ b/src/app/feature-set-creation/feature-set-creation.component.html
@@ -77,7 +77,7 @@
   <br>
 
   <button mat-raised-button color="primary" (click)="onSave()" [disabled]="isDisabled">Save</button> &nbsp;&nbsp; 
-  <button *ngIf="! isDisabled" mat-raised-button color="warn" (click)="onCancel()">Cancel</button>
-  <button *ngIf="isDisabled" mat-raised-button color="warn" (click)="onCancel()">Close</button>
+  <button *ngIf="! isDisabled" mat-raised-button color="warn" (click)="onCancel('no_saved')">Cancel</button>
+  <button *ngIf="isDisabled" mat-raised-button color="warn" (click)="onCancel('saved')">Close</button>
 
 </div>

--- a/src/app/feature-set-creation/feature-set-creation.component.ts
+++ b/src/app/feature-set-creation/feature-set-creation.component.ts
@@ -29,6 +29,7 @@ import { LocalStorageService } from '../core/services/local-storage.service';
 import { Variable } from '../shared/variable';
 import { FeatureSet } from '../shared/feature-set';
 import { NewVariableDialogComponent } from './new-variable-dialog/new-variable-dialog.component';
+import { DialogConfirmationComponent } from '../dialog-confirmation/dialog-confirmation.component';
 
 @Component({
   selector: 'app-feature-set-creation',
@@ -131,8 +132,31 @@ export class FeatureSetCreationComponent implements OnInit {
       }
   }
 
-  onCancel(): void {
-    console.log('Cancel feature set creation');
+  onCancel(status): void {
+
+    if (status === 'no_saved') {
+      const dialogConf = this.dialog.open(DialogConfirmationComponent, {
+        width: '500px',
+        data: {
+                title: 'Are you sure?',
+                message: 'The Feature set is not saved, are you sure you want to close?',
+                cancelButton: 'Keep here',
+                acceptButton: 'Close form'
+              }
+      });
+      dialogConf.afterClosed().subscribe(result => {
+        if (result) {
+          this.confirmCancel();
+        } else {
+          console.log('canceled close');
+        }
+      });
+    } else {
+      this.confirmCancel();
+    }
+  }
+
+  confirmCancel(): void {
     this.router.navigate(['/fslist']);
   }
 


### PR DESCRIPTION
## Proposed Changes

  - Dialog of confirmation when the user close the form of Feature set creation.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #181 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Created a component for confirmation dialogs, DialogConfirmationComponent, this component is global and can be used in the whole application.
- This new component can be configured from the component that call the dialog
- Parameters that the Dialog needs: title, message, cancelButton, acceptButton. all are of type string.
- Call this Component from the feature set dialog when the user clicks in the Cancel button and is creating a new Feature set.
- If the feature set already exists because the user is seeing the details, this Dialog will **NOT** open.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
