### PR TITLE
If the execution state of a data set is ready, go to 4th step

### DIFF
--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -28,6 +28,7 @@ import { of } from 'rxjs';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { FsDetailsDialogComponent } from './fs-details-dialog/fs-details-dialog.component';
+import { MatStepper } from '@angular/material/stepper';
 
 
 @Component({
@@ -68,7 +69,8 @@ export class DataSetCreationComponent implements OnInit {
   pattern = '^\/[?a-zA-Z0-9]+?[a-zA-Z0-9._%+-:=]{1,100}$';
 
   usecasename: string;
-
+  @ViewChild('stepper') stepper: MatStepper;
+  
   constructor(
     private formBuilder: FormBuilder,
     private backendService: BackendService,
@@ -184,6 +186,11 @@ export class DataSetCreationComponent implements OnInit {
         }
       });
 
+      // if the execution state is ready, go to the 4th step "Results & Statistics"
+      if (data.execution_state === 'ready') {
+        console.log("es ready")
+        this.stepper.selectedIndex = 3;
+      }
       this.completeddataTable = new MatTableDataSource(this.completedData);
       this.getDataSource(data.dataset_sources);
     });


### PR DESCRIPTION
## Proposed Changes

  - If the execution state of a data Set is ready, the application should go to the 4th step.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

The application go to the 1st step when the Data Set status is "ready".

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #193 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user clicks on see details of a Data Set, if the status is "ready", the app go to the 4th step.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No
