### PR TITLE
Do not allow the user to go to the next step if the form is empty in all steps

### DIFF
--- a/src/app/model-creation/model-creation.component.css
+++ b/src/app/model-creation/model-creation.component.css
@@ -141,3 +141,7 @@ table {
 .boosted_models_panel {
   display: flex;
 }
+
+::ng-deep .mat-horizontal-stepper-header{
+  pointer-events: none !important;
+}

--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -22,7 +22,8 @@
           <input matInput placeholder="Description" formControlName="description" required>
         </mat-form-field>
         <div>
-          <button mat-button matStepperNext>Next</button>
+          <button mat-button matStepperNext [disabled]="!formGroup1.valid && !newDMModel['model_id']">Next</button>
+          
         </div>
       </form>
     </mat-step>
@@ -38,9 +39,14 @@
               </th>
               <td mat-cell *matCellDef="let row" >
 
-                <mat-radio-button [value]="row" *ngIf="row.dataset_id != selectedDataSet.dataset_id" (change)="selectDataSet(row)"></mat-radio-button>
-                <mat-radio-button [value]="row" *ngIf="row.dataset_id === selectedDataSet.dataset_id" checked="true"></mat-radio-button>
-              </td>
+                <div *ngIf="selectedDataSet">
+                  <mat-radio-button [value]="row" *ngIf="row.dataset_id != selectedDataSet.dataset_id" (change)="selectDataSet(row)"></mat-radio-button>
+                  <mat-radio-button [value]="row" *ngIf="row.dataset_id === selectedDataSet.dataset_id" checked="true"></mat-radio-button>  
+                </div>
+                <div *ngIf="!selectedDataSet">
+                  <mat-radio-button [value]="row" (change)="selectDataSet(row)"></mat-radio-button>  
+                </div>
+                </td>
             </ng-container> 
 
             <ng-container matColumnDef="name">
@@ -67,8 +73,9 @@
             <tr mat-row *matRowDef="let row; columns: datasetSelectionDisplayedColumns;"></tr>
           </table>
         <div>
+          
           <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button mat-button matStepperNext [disabled]="!formGroup2.valid && !newDMModel['model_id']">Next</button>
         </div>
       </form>
     </mat-step>
@@ -208,7 +215,7 @@
           
         <div>
           <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button mat-button matStepperNext [disabled]="algorithmsList.length == 0 && !newDMModel['model_id']">Next</button>
         </div>
       </form>
     </mat-step>
@@ -271,11 +278,11 @@
           </mat-card>
 
         </div>
-        
 
         <div>
           <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext (click)="onSave()">Save and Next</button>
+          <button mat-button matStepperNext (click)="onSave()" [disabled]="!formGroup6.valid && !newDMModel['model_id']">Save and Next</button>
+          
         </div>
       </form>
     </mat-step>

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -128,6 +128,7 @@ export class ModelCreationComponent implements OnInit {
     if (history.state.selectedModel) {
       this.onSeeModel();
       this.formGroup1.disable();
+      this.formGroup1.markAllAsTouched();
       this.formGroup5.disable();
       this.isDisabled = true;
       this.componentDirection = 'Model edition';


### PR DESCRIPTION
## Proposed Changes

  - Dont allow the user to go to next step if the Model form is not completed.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

The application allow to go to any step if the form is not completed.

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #198 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If any step in the form is not completed, the user will can't go to the next step, the user should complete the fields in the current step to go to the next.
- In some steps, the formGroup should be valid, but in others an array will be not undefined.
- The navigation via header is disabled.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
To disable the header navigation will be modified the style sheet:

```
::ng-deep .mat-horizontal-stepper-header{
  pointer-events: none !important;
}
```
