### PR TITLE
Data Model go to the last step when user clicks see details

### DIFF
--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -16,7 +16,7 @@
  * information in the project root.
  */
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { LocalStorageService } from '../core/services/local-storage.service';
 
@@ -27,6 +27,7 @@ import { DmModel } from '../shared/dm-model';
 import { Algorithm } from '../shared/algorithm';
 import { Router } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
+import { MatStepper } from '@angular/material/stepper';
 
 @Component({
   selector: 'app-model-creation',
@@ -78,7 +79,7 @@ export class ModelCreationComponent implements OnInit {
   statisticsColumns: string[] = ['statistics', 'results'];
 
   algorithms = [];
-
+  @ViewChild('stepper') stepper: MatStepper;
   constructor(
     private backendService: BackendService,
     private localStorage: LocalStorageService,
@@ -124,13 +125,15 @@ export class ModelCreationComponent implements OnInit {
       test_size: ['', Validators.required],
       validation_size: ['', Validators.required]
     });
- 
+
     if (history.state.selectedModel) {
+
       this.onSeeModel();
       this.formGroup1.disable();
       this.formGroup5.disable();
       this.isDisabled = true;
       this.componentDirection = 'Model edition';
+
     } else {
       this.isDisabled = false;
       this.componentDirection = 'Model creation';
@@ -147,7 +150,6 @@ export class ModelCreationComponent implements OnInit {
       (datasets) => {
 
         datasets.forEach(element => {
-          console.log('EXECUTION STATE: ', element.execution_state);
           if (element.execution_state === 'final') {
             dataSets.push(element);
           }
@@ -177,6 +179,8 @@ export class ModelCreationComponent implements OnInit {
         if (this.newDMModel['data_mining_state'] === 'ready') {
           this.getStatistics();
         }
+
+        this.stepper.selectedIndex = 6;
       },
       (err) => {
         this.userCommunication.createMessage(this.userCommunication.ERROR, 'Get Model list operation failed');


### PR DESCRIPTION
## Proposed Changes

  - When the user clicks on see details in a Model, go to the last step of the form.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

- When the user clicks on see details of a Model, its open the first step of the form.

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #201 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user clicks on **see details** of a Model, the form is opened in the last step (7) - _Generate & Completed_.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

