### PR TITLE
refresh every 30 second to get actual data of executing data set

### DIFF
--- a/src/app/core/services/backend.service.ts
+++ b/src/app/core/services/backend.service.ts
@@ -161,8 +161,8 @@ export class BackendService {
     return this.httpClient.post(environment.restApiPPDDM + 'manager/predict', prediction, this.httpOptions);
   }
 
-  getProspectiveStudies(): Observable<any> {
-    return this.httpClient.get(environment.restApiPPDDM + 'manager/prospective', this.httpOptions);
+  getProspectiveStudies(id): Observable<any> {
+    return this.httpClient.get(environment.restApiPPDDM + 'manager/prospective?project_id=' + id, this.httpOptions);
   }
 
   onSaveprospectiveStudy(pospectiveStudy): Observable<any> {

--- a/src/app/data-set-creation/data-set-creation.component.ts
+++ b/src/app/data-set-creation/data-set-creation.component.ts
@@ -62,17 +62,14 @@ export class DataSetCreationComponent implements OnInit {
 
   completedData: string[] = [];
   completeddataTable = new MatTableDataSource(this.completedData);
-
   selectedFeatureSetRow: any;
-
   componentDirection: string;
-
   isDisabled: boolean;
   pattern = '^\/[?a-zA-Z0-9]+?[a-zA-Z0-9._%+-:=]{1,100}$';
 
   usecasename: string;
   @ViewChild('stepper') stepper: MatStepper;
-  
+
   constructor(
     private formBuilder: FormBuilder,
     private backendService: BackendService,
@@ -117,9 +114,18 @@ export class DataSetCreationComponent implements OnInit {
       this.formGroup1.disable();
       this.formGroup3.disable();
       this.onSeeDataSet();
+      setInterval(() => {
+        this.refreshDataSet();
+      }, 30000);
     } else {
       this.isDisabled = false;
       this.componentDirection = 'Data set creation';
+    }
+  }
+
+  refreshDataSet(): void {
+    if (this.newDataSet.execution_state === 'executing') {
+      this.onSeeDataSet();
     }
   }
 
@@ -187,9 +193,8 @@ export class DataSetCreationComponent implements OnInit {
       });
 
       // if the execution state is ready, go to the 4th step "Results & Statistics"
-      if (data.execution_state === 'ready') {
-        this.stepper.selectedIndex = 3;
-      }
+
+      this.stepper.selectedIndex = 3;
 
       data.dataset_sources.forEach(element => {
         if (element.selection_status === 'selected') {

--- a/src/app/prospective-study/prospective-study.component.ts
+++ b/src/app/prospective-study/prospective-study.component.ts
@@ -30,7 +30,7 @@ export class ProspectiveStudyComponent implements OnInit {
   }
 
   getProspectiveStudies(): void {
-    this.backendService.getProspectiveStudies().subscribe(
+    this.backendService.getProspectiveStudies(this.localStorage.projectId).subscribe(
       (data) => {
         console.log(data);
         this.dataSource = data;

--- a/src/app/shared/dataset.ts
+++ b/src/app/shared/dataset.ts
@@ -29,4 +29,5 @@ export class Dataset {
   created_on: string;
   dataset_id: string;
   dataset_sources: any;
+  execution_state: string;
 }


### PR DESCRIPTION
## Proposed Changes

  - Refresh every 30 second to get the actual data of executing state data sets.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #210 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user clicks on see details of a executing state data set, the aplication will show Quering...
- Every 30 second the component will request for new updates if the Data Set is on state "executing".
- Fixed the request for prospective studies.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
