### PR TITLE
calculate test size depending of trining size

### DIFF
--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -230,7 +230,6 @@
               <div class="col-1">
 
                 <label class="label-param">Trainig size</label> 
-                <label class="label-param">Validation size</label>
                 <label class="label-param">Test size</label>
               </div>
               <div class="col-2">
@@ -241,7 +240,8 @@
                   max="100"
                   class="slider-btn"
                   formControlName="training_size"
-                  name="test_size">
+                  name="test_size"
+                  (input)="changeTraining($event)">
                 </mat-slider>
 
                 <mat-slider
@@ -250,24 +250,14 @@
                   min="1"
                   max="100"
                   class="slider-btn"
-                  formControlName="validation_size">
-                </mat-slider> 
-
-                <mat-slider
-                  thumbLabel
-                  tickInterval="10"
-                  min="1"
-                  max="100"
-                  class="slider-btn"
-                  formControlName="test_size">
+                  formControlName="test_size"
+                  disabled="true">
                 </mat-slider> 
 
 
               </div>
               <div class="col-3">
                 <label > {{formGroup6.controls.training_size.value / 100}} </label>
-                <br>
-                <label > {{formGroup6.controls.validation_size.value / 100}}</label>
                 <br>
                 <label > {{formGroup6.controls.test_size.value / 100}}</label>
                 <br>

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -122,8 +122,8 @@ export class ModelCreationComponent implements OnInit {
     });
     this.formGroup6 = this.formBuilder.group({
       training_size: ['', Validators.required],
-      test_size: ['', Validators.required],
-      validation_size: ['', Validators.required]
+      test_size: [''],
+      validation_size: ['']
     });
 
     if (history.state.selectedModel) {
@@ -222,6 +222,12 @@ export class ModelCreationComponent implements OnInit {
     );
   }
 
+  changeTraining(event): void {
+    let testValue: number;
+    testValue = 100 - event.value;
+    this.formGroup6.controls.test_size.setValue(testValue);
+  }
+
   getCategorialVariables(): void {
     this.categorigalVariablesDataSource = [];
 
@@ -293,7 +299,7 @@ export class ModelCreationComponent implements OnInit {
     this.newDMModel.project_id = this.localStorage.projectId;
     this.newDMModel.training_size = this.formGroup6.get('training_size').value / 100;
     this.newDMModel.test_size = this.formGroup6.get('test_size').value / 100;
-    this.newDMModel.validation_size = this.formGroup6.get('validation_size').value / 100;
+    this.newDMModel.validation_size = 1;
 
     console.log('new model: ', this.newDMModel);
 


### PR DESCRIPTION
## Proposed Changes

  - the sum of training size and test size should be 100%.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #212 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Deleted the Validation size slider of the form, it will be 100%.
- Disabled the test size slider.
- When the user modify the training size slider, it call the `changeTraining()` method.
- This method get the value of training size and put the substraction of 100 - tsv.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
