### PR TITLE
delete use case from use case list, confirm message

### DIFF
--- a/src/app/core/services/backend.service.ts
+++ b/src/app/core/services/backend.service.ts
@@ -77,6 +77,11 @@ export class BackendService {
     return this.httpClient.post(environment.restApiPPDDM + 'manager/project', useCase, this.httpOptions);
   }
 
+  deleteUseCase(id): Observable<any> {
+    console.log(environment.restApiPPDDM + 'manager/project/' + id + '?_all');
+    return this.httpClient.delete(environment.restApiPPDDM + 'manager/project/' + id + '?_all')
+  }
+
   public getFeaturesetsList(id): Observable<any> {
     return this.httpClient.get(environment.restApiPPDDM + 'manager/featureset?project_id=' + id, this.httpOptions);
   }

--- a/src/app/use-case-list/use-case-list.component.html
+++ b/src/app/use-case-list/use-case-list.component.html
@@ -42,6 +42,15 @@
       <td mat-cell *matCellDef="let element"> {{element.created_on | date:'medium' }} </td>
     </ng-container>
 
+    <ng-container matColumnDef="delete">
+      <th mat-header-cell *matHeaderCellDef scope="col"> </th>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button aria-label="Delete" (click)="onDelete(element)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
     <ng-container matColumnDef="select">
       <th mat-header-cell *matHeaderCellDef> Select </th>
       <td mat-cell *matCellDef="let element">


### PR DESCRIPTION
## Proposed Changes

  - Delete use case.
  - Display message for confirmation.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #237 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Create a button to delete an use case, this icon is a trash can 🗑️ . This button calls the `onDelete()`.
- When the user clicks on this button, an confirmation message is displayed, this message tell the user if deletes the Use case, all the information related of this Use case will be deleted.
- If the user accept the deletetion, will call the service, passing the id of the Use case.
- When the Use Case is deleted, the component will refresh and display a information message.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


