### PR TITLE
set prediction as default at new use case form

### DIFF
--- a/src/app/usecase-creation/usecase-creation.component.html
+++ b/src/app/usecase-creation/usecase-creation.component.html
@@ -25,9 +25,9 @@
         <!-- use case TYPE drop-down-->
         <mat-form-field appearance="fill">
             <mat-label>Use case type</mat-label>
-            <mat-select formControlName="project_type"  matNativeControl name="select">
+            <mat-select formControlName="project_type" matNativeControl name="select">
                 <mat-option value="prediction">Prediction</mat-option>
-                <mat-option value="association">Association</mat-option>
+                <mat-option value="association" selected>Association</mat-option>
             </mat-select>
         </mat-form-field>
     </form>

--- a/src/app/usecase-creation/usecase-creation.component.ts
+++ b/src/app/usecase-creation/usecase-creation.component.ts
@@ -1,3 +1,4 @@
+import { SelectionModel } from '@angular/cdk/collections';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -25,7 +26,7 @@ export class UseCaseCreationComponent implements OnInit {
   useCaseForm = new FormGroup({
     name: new FormControl('', Validators.required),
     description: new FormControl('', Validators.required),
-    project_type: new FormControl('', Validators.required)
+    project_type: new FormControl('prediction', Validators.required)
   });
 
   ngOnInit(): void {


### PR DESCRIPTION
## Proposed Changes

  - In the new use case form' set "prediction" as the dafeult the use case type.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #243 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- In the new use case form' set "prediction" as the dafeult the use case type.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
