### PR TITLE
data model form step 6 training size to 80

### DIFF
--- a/src/app/model-creation/model-creation.component.css
+++ b/src/app/model-creation/model-creation.component.css
@@ -81,7 +81,7 @@ table {
 }
 
 .params-card {
-  width: 50%;
+  width: 70%;
   margin-left: auto;
   margin-right: auto;
   text-align: center;
@@ -144,4 +144,8 @@ table {
 
 ::ng-deep .mat-horizontal-stepper-header{
   pointer-events: none !important;
+}
+
+.little-letter{
+
 }

--- a/src/app/model-creation/model-creation.component.html
+++ b/src/app/model-creation/model-creation.component.html
@@ -230,7 +230,9 @@
               <div class="col-1">
 
                 <label class="label-param">Trainig size</label> 
+                <small class="little-letter">Data set to be used for train the model.</small>
                 <label class="label-param">Test size</label>
+                <small class="little-letter">Data set to evaluate the model once it is created.</small>
               </div>
               <div class="col-2">
                 <mat-slider

--- a/src/app/model-creation/model-creation.component.ts
+++ b/src/app/model-creation/model-creation.component.ts
@@ -121,8 +121,8 @@ export class ModelCreationComponent implements OnInit {
       formGroup7: ['', Validators.required]
     });
     this.formGroup6 = this.formBuilder.group({
-      training_size: ['', Validators.required],
-      test_size: [''],
+      training_size: [80, Validators.required],
+      test_size: [20],
       validation_size: ['']
     });
 


### PR DESCRIPTION
## Proposed Changes

  - Set the trining size to 80 and the test size to 20 by default.
  - add annotation under the data tittle:
       - **Training size**: Data set to be used for train the model.
       - **Testing size**: Data set to evaluate the model once it is created.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

  - Seted the trining size to 80 and the test size to 20 by default.
  - Added a little annotation under the data tittle:
       - **Training size**: Data set to be used for train the model.
       - **Testing size**: Data set to evaluate the model once it is created.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
