### PR TITLE
error when there not variables in new feature set

### DIFF
--- a/src/app/feature-set-creation/feature-set-creation.component.ts
+++ b/src/app/feature-set-creation/feature-set-creation.component.ts
@@ -148,7 +148,7 @@ export class FeatureSetCreationComponent implements OnInit {
           (err) => {
             this.backendService.handleError('home', err);
             console.log('error', err);
-            this.userCommunication.createMessage(this.userCommunication.ERROR, 'New feature set creation failed!');
+            this.userCommunication.createMessage(this.userCommunication.ERROR, err.error);
           });
       } else {
         const dialogConf = this.dialog.open(DialogConfirmationComponent, {


### PR DESCRIPTION
## Proposed Changes

  - Display message when the user don't set variables in the Feature set creation.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [ ] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #258 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the user forget to add variables, and the user saves the feature set the application notify the user with an error message.
- The error message says: _UNKNOWN EXCEPTION: A feature set must include at least one variable_.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
