### PR TITLE
change Observation fhirPath in automatic variables

### DIFF
--- a/src/app/core/automatic-variables.json
+++ b/src/app/core/automatic-variables.json
@@ -11,7 +11,7 @@
   {"name": "Number of prescribed drugs",    "fieldType":"disabled", "dataType":"numeric",   "fhirQuery":"/MedicationStatement", "fhirPath": "aggr:groupBy(MedicationStatement.context.reference,count())"},
   {"name": "Condition", "fieldType": "text", "dataType": "numeric", "fhirQuery": "/Condition?code:sw={string_value}", "fhirPath": "value:exists"},
   {"name": "Medication", "fieldType": "text", "dataType": "numeric", "fhirQuery": "/MedicationStatement?code={string_value}", "fhirPath": "value:exists"},
-  {"name": "Observation", "fieldType": "text", "dataType": "numeric", "fhirQuery": "/Observation?code={string_value}", "fhirPath": "value:Observation.valueQuantity.value"},
+  {"name": "Observation", "fieldType": "text", "dataType": "numeric", "fhirQuery": "/Observation?code={string_value}", "fhirPath": "value:exists"},
   {"name":"Lab Result at admission", "fieldType":   "text", "dataType":"numeric", "fhirQuery":  "/Observation?code={string_value}&_sort=date", "fhirPath": "value:Observation.valueQuantity.value"},
   {"name":"Lab Result at discharge", "fieldType":   "text", "dataType":"numeric", "fhirQuery":  "/Observation?code={string_value}&_sort=-date", "fhirPath": "value:Observation.valueQuantity.value"},
   {"name":"Readmitted in X days", "fieldType":  "number",   "dataType":"numeric", "fhirQuery":  "/Encounter", "fhirPath": "value:readmission:{integer_value}"},


### PR DESCRIPTION
## Proposed Changes

  - Change **Observation** resource while adding a new variable. The GUI currently generates “_value:Observation.valueQuantity.value_”, but it should be “_value:exists_” instead 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [ ] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: N/A

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed the fhirPath of **Observation** variable to _value:exists_.


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
